### PR TITLE
Set vimrc to autowrap git commit messages.

### DIFF
--- a/files/debian.vimrc
+++ b/files/debian.vimrc
@@ -114,3 +114,6 @@ highlight ExtraWhitespace ctermbg=red guibg=red
 let a = matchadd('ExtraWhitespace', '\s\+$')
 highlight OverLength ctermbg=red ctermfg=white guibg=red guifg=white
 let b = matchadd('OverLength', '\(^\(\s\)\{-}\(*\|//\|/\*\)\{1}\(.\)*\(\%81v\)\)\@<=\(.\)\{1,}$')
+
+" Autowrap git commit messags.
+au FileType gitcommit set tw=65


### PR DESCRIPTION
To make our commit messages nicer, add a config line to the default vimrc file to autowrap them.