### PR TITLE
Add "git br" as an alias for "git branch"

### DIFF
--- a/files/gitconfig
+++ b/files/gitconfig
@@ -3,6 +3,7 @@
   st = status
   ci = commit
   ba = branch -a
+  br = branch
   commush = !git commit -a && git push
   cu = !git commit -a && git push
   df = !git diff --no-prefix && git diff --staged --no-prefix


### PR DESCRIPTION
This is a useful shortcut that I find myself missing on servers and our VMs.